### PR TITLE
Fix: database column length for root_address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ jspm_packages
 .DS_Store
 
 coverage
+
+*.log
+*.nvmrc

--- a/sql/create_root_store_addresses.sql
+++ b/sql/create_root_store_addresses.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE public.root_store_addresses
 (
-    root_store_address VARCHAR(46) NOT NULL, --OrbitDB root store address
+    root_store_address VARCHAR(200) NOT NULL, --OrbitDB root store address
     did VARCHAR(64), -- did
     CONSTRAINT root_store_addresses_pkey PRIMARY KEY (did)
 )


### PR DESCRIPTION
This change is already applied, since we had no data.
For other database migrations an `ALTER TABLE` statement should go on the `.sql` files to keep consistency and make issues reproducible.