### PR TITLE
feat: use 3box pinning server, and dont validate existing dids

### DIFF
--- a/src/api/__tests__/root_store_address_post.test.js
+++ b/src/api/__tests__/root_store_address_post.test.js
@@ -6,7 +6,8 @@ describe('RootStoreAddressPost', () => {
   let sut
   let uPortMgrMock = new UportMgr()
   let addressMgrMock = {
-    store: jest.fn()
+    store: jest.fn(),
+    get: (did) => false
   }
 
   const validToken =

--- a/src/api/root_store_address_post.js
+++ b/src/api/root_store_address_post.js
@@ -20,20 +20,27 @@ class RootStoreAddressPost {
       return
     }
 
-    let payload
-    try {
-      let dtoken = await this.uPortMgr.verifyToken(body.address_token)
-      payload = dtoken.payload
-    } catch (error) {
-      console.log('Error on this.uportMgr.verifyToken')
-      console.log(error)
-      cb({ code: 401, message: 'Invalid JWT' })
-      return
-    }
+    const payload = this.uPortMgr.parseToken(body.address_token).payload
 
     // Check if root store address is present
     if (!payload.rootStoreAddress) {
       cb({ code: 403, message: 'Missing data' })
+      return
+    }
+
+    // Get rsAddress for did from db
+    const rsAddress = await this.addressMgr.get(payload.iss)
+    if (rsAddress) {
+      cb(null, payload.rootStoreAddress)
+      return
+    }
+
+    try {
+      await this.uPortMgr.verifyToken(body.address_token)
+    } catch (error) {
+      console.log('Error on this.uportMgr.verifyToken')
+      console.log(error)
+      cb({ code: 401, message: 'Invalid JWT' })
       return
     }
 

--- a/src/lib/uPortMgr.js
+++ b/src/lib/uPortMgr.js
@@ -1,13 +1,19 @@
-import { verifyJWT } from "did-jwt";
+import { verifyJWT, decodeJWT } from "did-jwt";
+
+const muportOpts = { ipfsConf: { protocol: 'https', host: 'ipfs.3box.io'}}
 
 require("uport-did-resolver")();
 require("ethr-did-resolver")();
-require("muport-did-resolver")();
+require("muport-did-resolver")(muportOpts);
 
 class UportMgr {
   async verifyToken(token) {
     if (!token) throw new Error("no token");
     return verifyJWT(token);
+  }
+
+  parseToken(jwt) {
+    return decodeJWT(jwt)
   }
 }
 


### PR DESCRIPTION
May want to return to generalized later again, where any post with valid token can write values. 

This adds a condition that, it only writes and verifies token in request if there is no entry already. This allows libs current and future to work with ipfs, were past ones are already written and new ones are created with 3box pinning server and verified there. 

We may solve this on our pinning server as well, but this likely a quicker more clear solution for now, since time is limited.